### PR TITLE
Make provider error more descriptive

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -388,7 +388,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -430,7 +430,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   timing:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -206,7 +206,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.0-dev.4"
+    version: "0.2.0-rc.1"
   former_gen:
     dependency: "direct dev"
     description:
@@ -388,7 +388,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
@@ -430,7 +430,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.2.19"
   timing:
     dependency: transitive
     description:

--- a/lib/src/utils/assert_has_generic.dart
+++ b/lib/src/utils/assert_has_generic.dart
@@ -1,0 +1,27 @@
+import '../former_form.dart';
+
+/// Asserts that [TForm] is given to the former widget with the name [forWidget].
+/// Used by Former widgets to ensure that the type of the form is passed,
+/// so that they can locate and obtain the correct form.
+///
+/// Example:
+/// ```
+/// // Asserts that the type LoginForm is passed to FormerTextField.
+/// assertHasGeneric<LoginForm>(forWidget: 'FormerTextField');
+/// ```
+void assertHasGeneric<TForm extends FormerForm>({required String forWidget}) {
+  assert(
+    TForm != FormerForm,
+    '''You must pass in the type of your form that this Former widget is consuming, so that the widget can locate and obtain the correct form.
+Example:
+
+$forWidget<MyForm>(
+          ^^^^^^^^
+          Pass in the type of your form here.
+
+  ...other params,
+),
+
+This assertion is made by: $forWidget''',
+  );
+}

--- a/lib/src/utils/assert_has_generic.dart
+++ b/lib/src/utils/assert_has_generic.dart
@@ -16,7 +16,7 @@ void assertHasGeneric<TForm extends FormerForm>({required String forWidget}) {
 Example:
 
 $forWidget<MyForm>(
-          ^^^^^^^^
+${' ' * forWidget.length}^^^^^^^^
           Pass in the type of your form here.
 
   ...other params,

--- a/lib/src/widgets/former_checkbox.dart
+++ b/lib/src/widgets/former_checkbox.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:provider/provider.dart';
 
+import '../utils/assert_has_generic.dart';
 import '../former_form.dart';
 import '../former_field.dart';
 import '../former_provider.dart';
@@ -91,6 +92,8 @@ class _FormerCheckboxState<F extends FormerForm> extends State<FormerCheckbox> {
   @override
   void initState() {
     super.initState();
+
+    assertHasGeneric<F>(forWidget: 'FormerCheckbox');
 
     _formProvider = Former.of(context, listen: false);
     final initialValue = _formProvider.form[widget.field];

--- a/lib/src/widgets/former_error.dart
+++ b/lib/src/widgets/former_error.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../utils/assert_has_generic.dart';
 import '../former_form.dart';
 import '../former_field.dart';
 import '../former_provider.dart';
@@ -59,6 +60,8 @@ class FormerError<TForm extends FormerForm> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    assertHasGeneric<TForm>(forWidget: 'FormerError');
+
     final child = this.child;
     if (child != null) return child;
 

--- a/lib/src/widgets/former_slider.dart
+++ b/lib/src/widgets/former_slider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:provider/provider.dart';
 
+import '../utils/assert_has_generic.dart';
 import '../former_field.dart';
 import '../former_form.dart';
 import '../former_provider.dart';
@@ -105,6 +106,8 @@ class _FormerSliderState<F extends FormerForm> extends State<FormerSlider> {
   @override
   void initState() {
     super.initState();
+
+    assertHasGeneric<F>(forWidget: 'FormerSlider');
 
     _formProvider = Former.of(context, listen: false);
     final initialValue = _formProvider.form[widget.field];

--- a/lib/src/widgets/former_switch.dart
+++ b/lib/src/widgets/former_switch.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:provider/provider.dart';
 
+import '../utils/assert_has_generic.dart';
 import '../former_form.dart';
 import '../former_field.dart';
 import '../former_provider.dart';
@@ -96,6 +97,8 @@ class _FormerSwitchState<F extends FormerForm> extends State<FormerSwitch> {
   @override
   void initState() {
     super.initState();
+
+    assertHasGeneric<F>(forWidget: 'FormerSwitch');
 
     _formProvider = Former.of(context, listen: false);
     final initialValue = _formProvider.form[widget.field];

--- a/lib/src/widgets/former_text_field.dart
+++ b/lib/src/widgets/former_text_field.dart
@@ -6,6 +6,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
+import '../utils/assert_has_generic.dart';
 import '../former_form.dart';
 import '../former_field.dart';
 import '../former_provider.dart';
@@ -159,6 +160,8 @@ class _FormerTextFieldState<F extends FormerForm>
   @override
   void initState() {
     super.initState();
+
+    assertHasGeneric<F>(forWidget: 'FormerTextField');
 
     final formProvider = Former.of<F>(context, listen: false);
     final initialValue = formProvider.form[widget.field];

--- a/test/utils/assert_has_generic_test.dart
+++ b/test/utils/assert_has_generic_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:former/src/utils/assert_has_generic.dart';
+
+import '../test_form.dart';
+
+void main() {
+  group('assertHasGeneric', () {
+    test('should fail assertion if no generic type is passed to function call',
+        () {
+      expect(
+        () => assertHasGeneric(forWidget: 'TestWidget'),
+        throwsA(TypeMatcher<AssertionError>()),
+      );
+    });
+
+    test(
+        'should not fail assertion if a generic type that extends FormerForm is passed to function call',
+        () {
+      expect(
+        () => assertHasGeneric<TestForm>(forWidget: 'TestWidget'),
+        returnsNormally,
+      );
+    });
+  });
+}

--- a/test/widgets/former_checkbox_test.dart
+++ b/test/widgets/former_checkbox_test.dart
@@ -16,6 +16,16 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets('should fail assertion if the type of the form is not passed',
+        (tester) async {
+      await tester.pumpWidget(
+        wrapWithFormer(
+          control: FormerCheckbox(field: TestFormField.boolField),
+        ),
+      );
+      expect(tester.takeException(), isInstanceOf<AssertionError>());
+    });
+
     testWidgets(
       'should fail assertion if incompatible field is passed',
       (tester) async {

--- a/test/widgets/former_error_test.dart
+++ b/test/widgets/former_error_test.dart
@@ -18,6 +18,15 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets('should fail assertion if the type of the form is not passed', (tester) async {
+      await tester.pumpWidget(
+        wrapWithFormer(
+          control: FormerError(field: TestFormField.stringField),
+        ),
+      );
+      expect(tester.takeException(), isInstanceOf<AssertionError>());
+    });
+
     testWidgets('should show error of the field', (tester) async {
       final error = GlobalKey();
 

--- a/test/widgets/former_slider.dart
+++ b/test/widgets/former_slider.dart
@@ -16,6 +16,16 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets('should fail assertion if the type of the form is not passed',
+        (tester) async {
+      await tester.pumpWidget(
+        wrapWithFormer(
+          control: FormerSlider(field: TestFormField.intField),
+        ),
+      );
+      expect(tester.takeException(), isInstanceOf<AssertionError>());
+    });
+
     testWidgets(
       'should fail assertion if incompatible field is used',
       (tester) async {

--- a/test/widgets/former_switch_test.dart
+++ b/test/widgets/former_switch_test.dart
@@ -16,6 +16,16 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets('should fail assertion if the type of the form is not passed',
+        (tester) async {
+      await tester.pumpWidget(
+        wrapWithFormer(
+          control: FormerSwitch(field: TestFormField.boolField),
+        ),
+      );
+      expect(tester.takeException(), isInstanceOf<AssertionError>());
+    });
+
     testWidgets(
       'should fail assertion when incompatible field is used',
       (tester) async {

--- a/test/widgets/former_text_field_test.dart
+++ b/test/widgets/former_text_field_test.dart
@@ -17,6 +17,16 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets('should fail assertion if the type of the form is not passed',
+        (tester) async {
+      await tester.pumpWidget(
+        wrapWithFormer(
+          control: FormerTextField(field: TestFormField.stringField),
+        ),
+      );
+      expect(tester.takeException(), isInstanceOf<AssertionError>());
+    });
+
     testWidgets(
       'should fail assertion if field is a nullable number but keyboard type is not number',
       (tester) async {


### PR DESCRIPTION
Former widgets should show a helpful error message when the type of the form the widgets are consuming is not passed. For example:
```dart
FormerTextField()
```
should throw an `AssertionError` with a helpful error message:
```
You must pass in the type of your form that this Former widget is consuming, so that the widget can locate and obtain the correct form.
Example:

FormerTextField<MyForm>(
               ^^^^^^^^
               Pass in the type of your form here.

  ...other params,
),

This assertion is made by: FormerTextField.
```

Closes #3 

cc @PiotrekPKP